### PR TITLE
Hide debug canvas by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,6 @@
       </div>
     </div>
   </div>
-  <canvas id="debugcanvas" width='1000' height='480' style='border:1px solid black;'></canvas>
+  <canvas id="debugcanvas" width='1000' height='480' style='display:none;'></canvas>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Sets `display:none` on the `#debugcanvas` element so the Box2D physics wireframe canvas is no longer visible to players
- The canvas element and debug draw setup remain in place and can be re-enabled during development by toggling the style

Closes #18