### PR TITLE
Fix mousedownhandler calling ev.originalEvent.preventDefault()

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -977,7 +977,7 @@ const mouse = {
     mouse.down = true;
     mouse.downX = mouse.x;
     mouse.downY = mouse.y;
-    ev.originalEvent.preventDefault();
+    ev.preventDefault();
   },
   // Makes sure that clicks and drags are cut off when the mouse cursor leaves the canvas
   mouseuphandler(ev) {


### PR DESCRIPTION
## Summary
- Replaces `ev.originalEvent.preventDefault()` with `ev.preventDefault()`
- `originalEvent` is a jQuery wrapper property; native `MouseEvent` objects do not have it, so the old call threw a `TypeError` at runtime and `preventDefault` was never invoked

Closes #19