### PR TITLE
Fix game.bounceSound never initialized

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -71,7 +71,8 @@ const game = {
 
     // Load sound effects and music
     game.backgroundMusic = loader.loadSound("audio/fruit-fling-symphony");
-    game.slingshotReleasedSound = loader.loadSound("audio/bounce");
+    game.bounceSound = loader.loadSound("audio/bounce");
+    game.slingshotReleasedSound = loader.loadSound("audio/released");
     game.breakSound = {
       glass: loader.loadSound("audio/glassbreak"),
       wood: loader.loadSound("audio/woodbreak"),


### PR DESCRIPTION
## Summary
- Adds `game.bounceSound = loader.loadSound('audio/bounce')` to `game.init()` so entity collision sounds actually play
- Corrects `game.slingshotReleasedSound` to use the `audio/released` asset (which was sitting unused in the repo) rather than `audio/bounce`

Closes #20