### PR TITLE
Add touch event support for mobile play

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -961,6 +961,10 @@ const mouse = {
     canvas.addEventListener("mousedown", mouse.mousedownhandler);
     canvas.addEventListener("mouseup", mouse.mouseuphandler);
     canvas.addEventListener("mouseout", mouse.mouseuphandler);
+    // Touch events for mobile devices
+    canvas.addEventListener("touchmove", mouse.touchmovehandler, { passive: false });
+    canvas.addEventListener("touchstart", mouse.touchstarthandler, { passive: false });
+    canvas.addEventListener("touchend", mouse.mouseuphandler);
   },
   // Handles general mouse movement on the canvas
   mousemovehandler(ev) {
@@ -983,6 +987,24 @@ const mouse = {
   mouseuphandler(ev) {
     mouse.down = false;
     mouse.dragging = false;
+  },
+  touchmovehandler(ev) {
+    ev.preventDefault();
+    const touch = ev.touches[0];
+    const rect = document.getElementById("gamecanvas").getBoundingClientRect();
+    mouse.x = touch.clientX - rect.left;
+    mouse.y = touch.clientY - rect.top;
+    if (mouse.down) {
+      mouse.dragging = true;
+    }
+  },
+  touchstarthandler(ev) {
+    ev.preventDefault();
+    mouse.down = true;
+    const touch = ev.touches[0];
+    const rect = document.getElementById("gamecanvas").getBoundingClientRect();
+    mouse.x = touch.clientX - rect.left;
+    mouse.y = touch.clientY - rect.top;
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `touchmove` and `touchstart` handlers to `mouse.init()` that translate touch coordinates to the same `mouse.x/y/down/dragging` state the game loop already reads
- Maps `touchend` to the existing `mouseuphandler`
- Both touch listeners use `{ passive: false }` so `preventDefault()` can suppress browser scroll/zoom during play

Closes #21