### PR TITLE
Remove stale comments and commented-out code

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Froot Wars</title>
-  <!--/*<script src="./js/box2d.js"></script>*/-->
   <script src="js/Box2dWeb-2.1.a.3.min.js" type='text/javascript' charset='utf-8'></script>
   <script src="./js/game.js"></script>
   <link rel="stylesheet" type="text/css" href="./css/styles.css">

--- a/js/game.js
+++ b/js/game.js
@@ -1,4 +1,3 @@
-// Ghetto Import Box2D
 const b2Vec2 = Box2D.Common.Math.b2Vec2;
 const b2BodyDef = Box2D.Dynamics.b2BodyDef;
 const b2Body = Box2D.Dynamics.b2Body;
@@ -120,12 +119,9 @@ const game = {
       game.offsetLeft <= game.maxOffset &&
       game.offsetLeft >= game.minOffset
     ) {
-      // Set deltaX to the mininum distance needed to get the newCenter within the center 50% of the screen.
-      // Why divide by 2 though????
       let deltaX = Math.round(
         (newCenter - game.offsetLeft - game.canvas.width / 4) / 2
       );
-      // Here maxSpeed seems to speed up panning, now slow it down???
       if (deltaX && Math.abs(deltaX) > game.maxSpeed) {
         deltaX = (game.maxSpeed * Math.abs(deltaX)) / deltaX;
       }
@@ -175,7 +171,6 @@ const game = {
   handlePanning() {
     debugLog("Game mode is ", game.mode);
     if (game.mode === "intro") {
-      //why coerce?
       if (game.panTo(700)) {
         game.mode = "load-next-hero";
       }
@@ -249,7 +244,6 @@ const game = {
     if (game.mode === "fired") {
       // Pan to where hero is
       const heroX = game.currentHero.GetPosition().x * box2d.scale;
-      //console.log("HERO :", game.currentHero);
       game.panTo(heroX);
       // And when the hero falls asleep or leaves the gameboard, delete him and load the next hero
       const elapsedTime = (new Date().getTime() - game.fireTimer) / 1000;
@@ -830,8 +824,6 @@ const levels = {
   ],
   init() {
     let html = "";
-    // Dynamically create level buttons for all level objects in levels.data
-    //seem like a silly use of forEach since we only use the index
     levels.data.forEach((level, index) => {
       html += `<input type='button' value=${index + 1}>`;
     });
@@ -887,9 +879,6 @@ const loader = {
   soundFileExtn: ".ogg",
 
   init() {
-    // determine compatible game music for browser.
-    // audio.canPlayType returns strings like 'maybe' or 'probably' to guess if audio will play
-    // I suspect that mp3 now plays on all browsers????
     let mp3Support, oggSupport;
     const audio = document.createElement("audio");
     if (audio.canPlayType) {
@@ -1044,7 +1033,6 @@ const entities = {
       shape: "circle",
       radius: 20,
       density: 1.5,
-      // friction: 0.5,
       friction: 1,
       restitution: 0.4,
     },
@@ -1052,7 +1040,6 @@ const entities = {
       shape: "circle",
       radius: 20,
       density: 1.5,
-      // friction: 0.5,
       friction: 1,
       restitution: 0.4,
     },
@@ -1060,7 +1047,6 @@ const entities = {
       shape: "circle",
       radius: 10,
       density: 2.0,
-      // friction: 0.5,
       friction: 1,
       restitution: 0.4,
     },


### PR DESCRIPTION
## Summary
- Removes dead `<script>` comment in `index.html`
- Removes 'Ghetto Import Box2D' heading comment
- Removes unanswered developer questions left in `panTo`
- Removes commented-out `console.log` in fired mode
- Removes speculative browser-support comment in `loader.init`
- Removes redundant `forEach` description in `levels.init`
- Removes stale `// friction: 0.5` lines in apple/orange/strawberry definitions

Closes #24