### PR TITLE
Fix block entities missing bounceSound assignment

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1090,6 +1090,7 @@ const entities = {
           "images/entities/" + entity.name + ".png"
         );
         entity.breakSound = game.breakSound[entity.name];
+        entity.bounceSound = game.bounceSound;
         box2d.createRectangle(entity, definition);
         break;
       case "ground":


### PR DESCRIPTION
## Summary

- Assigns `game.bounceSound` to `block` entities (wood, glass) in `entities.create()`, matching what heroes and villains already receive
- PR #28 initialized `game.bounceSound` but only wired it to heroes and villains — all block-vs-block and block-vs-ground contacts were silent
- The entire physics cascade after the initial throw now produces collision sounds

## Test plan

- [ ] Start any level and throw a fruit into the tower
- [ ] Listen for bounce sounds as blocks tumble and hit each other and the ground
- [ ] Verify sounds play throughout the cascade, not just on the initial hero impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)