### PR TITLE
Replace new Date().getTime() with performance.now() / rAF timestamp

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -234,7 +234,7 @@ const game = {
           impulseScaleFactor,
           (game.slingshotY + 25 - mouse.y) * impulseScaleFactor
         );
-        game.fireTimer = new Date().getTime();
+        game.fireTimer = performance.now();
         game.currentHero.ApplyImpulse(
           impulse,
           game.currentHero.GetWorldCenter()
@@ -247,7 +247,7 @@ const game = {
       const heroX = game.currentHero.GetPosition().x * box2d.scale;
       game.panTo(heroX);
       // And when the hero falls asleep or leaves the gameboard, delete him and load the next hero
-      const elapsedTime = (new Date().getTime() - game.fireTimer) / 1000;
+      const elapsedTime = (performance.now() - game.fireTimer) / 1000;
       debugLog("Time: ", elapsedTime);
       if (
         !game.currentHero.IsAwake() ||
@@ -272,19 +272,18 @@ const game = {
     }
   },
 
-  animate() {
+  animate(timestamp) {
     // Animate the background
     game.handlePanning();
 
     // Animate the characters using a variable step rate derived from the framerate of requestAnimationFrame
-    const currentTime = new Date().getTime();
     let timeStep;
     if (game.lastUpdateTime) {
-      timeStep = (currentTime - game.lastUpdateTime) / 1000;
+      timeStep = (timestamp - game.lastUpdateTime) / 1000;
       box2d.step(timeStep);
     }
 
-    game.lastUpdateTime = currentTime;
+    game.lastUpdateTime = timestamp;
 
     // Draw the background with parallax
     game.context.drawImage(


### PR DESCRIPTION
## Summary

Closes #38

- `animate()` now accepts the `timestamp` argument passed by `requestAnimationFrame` and uses it directly for the physics timestep calculation, eliminating the `new Date().getTime()` call there.
- `game.fireTimer` (set on launch, read for the 10 s hero timeout) is now stamped with `performance.now()` instead of `new Date().getTime()`. Both `performance.now()` and the rAF timestamp share the same time origin, so the elapsed-time comparison in `handlePanning` remains accurate.

`performance.now()` is monotonic and high-resolution; wall-clock time can jump backwards on NTP sync or DST changes, making it wrong for animation timing.

## Test plan

- [x] Start the game and play a level — physics and animation run at normal speed
- [x] Fire a hero and confirm the 10 s fallback timeout (hero with no targets to hit) still triggers and loads the next hero
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)