### PR TITLE
Add favicon link to suppress 404 console noise

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Froot Wars</title>
+  <link rel="icon" href="data:,">
   <script src="js/Box2dWeb-2.1.a.3.min.js" type='text/javascript' charset='utf-8'></script>
   <script src="./js/game.js"></script>
   <link rel="stylesheet" type="text/css" href="./css/styles.css">


### PR DESCRIPTION
## Summary

- Adds `<link rel="icon" href="data:,">` to `index.html` `<head>`
- Eliminates the two `/favicon.ico` 404 errors logged on every page load
- No extra file needed — the `data:` URI tells the browser the icon is an empty resource

Closes #54

## Test plan

- [ ] Open the game in a browser (served over HTTP)
- [ ] Open DevTools → Console
- [ ] Confirm no `favicon.ico` 404 errors appear on load or navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)