### PR TITLE
Guard PostSolve against null userData

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1252,22 +1252,17 @@ class Box2d {
       const entity1 = body1.GetUserData();
       const entity2 = body2.GetUserData();
 
-      // Guard against bodies with no userData (e.g. static ground bodies)
-      if (!entity1 || !entity2) return;
-
       const impulseAlongNormal = Math.abs(impulse.normalImpulses[0]);
       // Filter out tiny impulses
       if (impulseAlongNormal > 5) {
-        // Reduce object health by impulse value if they have health
-        if (entity1.health !== undefined) {
-          entity1.health -= impulseAlongNormal;
+        if (entity1) {
+          if (entity1.health !== undefined) entity1.health -= impulseAlongNormal;
+          if (entity1.bounceSound) entity1.bounceSound.play();
         }
-        if (entity2.health !== undefined) {
-          entity2.health -= impulseAlongNormal;
+        if (entity2) {
+          if (entity2.health !== undefined) entity2.health -= impulseAlongNormal;
+          if (entity2.bounceSound) entity2.bounceSound.play();
         }
-        // Play bounce sounds
-        if (entity1.bounceSound) entity1.bounceSound.play();
-        if (entity2.bounceSound) entity2.bounceSound.play();
       }
     };
     this.world.SetContactListener(listener);

--- a/js/game.js
+++ b/js/game.js
@@ -1252,6 +1252,9 @@ class Box2d {
       const entity1 = body1.GetUserData();
       const entity2 = body2.GetUserData();
 
+      // Guard against bodies with no userData (e.g. static ground bodies)
+      if (!entity1 || !entity2) return;
+
       const impulseAlongNormal = Math.abs(impulse.normalImpulses[0]);
       // Filter out tiny impulses
       if (impulseAlongNormal > 5) {


### PR DESCRIPTION
## Summary

Add early-return null checks for `entity1` and `entity2` in the Box2D `PostSolve` contact listener. Static bodies such as ground tiles do not have `userData` set, so `GetUserData()` returns `null` for them. Without this guard, any collision involving a ground body throws a TypeError when the code tries to read `.health` or `.bounceSound` off `null`.

Closes #57