### PR TITLE
Reset asset loader counters on level load

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -871,6 +871,10 @@ const levels = {
   load(number) {
     debugLog("load called for ", number);
     box2d.init();
+    // Reset asset counters so load-complete detection works correctly on restart
+    loader.loadedCount = 0;
+    loader.totalCount = 0;
+    loader.loaded = true;
     game.currentLevel = {
       number: number,
     };


### PR DESCRIPTION
## Summary

Reset `loader.loadedCount`, `loader.totalCount`, and `loader.loaded` at the start of `levels.load()` so that load-complete detection works correctly when restarting or advancing to the next level. Without this reset, the counters accumulate across loads — `loadedCount` already equals `totalCount` from the previous level, so the `itemLoaded` callback never fires `loader.onload` and `game.start()` is never called on subsequent level loads.

Closes #58