### PR TITLE
dep: Update globals from v15 to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@eslint/js": "^9.13.0",
         "eslint": "^9.13.0",
-        "globals": "^15.11.0",
+        "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "vitest": "^4.1.8"
       }
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "eslint": "^9.13.0",
-    "globals": "^15.11.0",
+    "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "vitest": "^4.1.8"
   }


### PR DESCRIPTION
## Summary

- Updates `globals` dev dependency from `^15.11.0` to `^17.6.0` (two major versions)
- Adds ES2025 globals (Iterator helpers, `Promise.try`, `Float16Array`), modern browser globals (`URLPattern`, CompressionStreams API), and updated Node 22 built-ins
- No changes to `eslint.config.js` — package shape is stable across these versions

Closes #69

## Test plan

- [x] `npm install` succeeds (0 vulnerabilities)
- [x] All 48 unit tests pass (`npm test`)
- [x] `npm run lint` exits clean with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)