### PR TITLE
Add TypeScript type-checking via JSDoc (no build step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Test
         run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,31 @@ change, manually walk through: main menu → level select → play one level →
 fire a hero → confirm score updates → restart. Check the browser console for
 errors.
 
-## Tests and linting
+## Tests, linting, and type-checking
 
-There is a Vitest unit-test suite and ESLint config (dev-only; the game still
-ships with no build step and runs straight from the static files). Install dev
-dependencies once with `npm install`, then:
+There is a Vitest unit-test suite, an ESLint config, and TypeScript type-checking
+(all dev-only; the game still ships with no build step and runs straight from the
+static files). Install dev dependencies once with `npm install`, then:
 
 ```sh
-npm test    # Vitest, jsdom environment
+npm test         # Vitest, jsdom environment
 npm run lint
+npm run typecheck # tsc --noEmit over the JSDoc-typed source
 ```
+
+The source is plain JavaScript type-checked in place: [js/game.js](js/game.js)
+opens with `// @ts-check`, its types live in JSDoc comments (`@typedef`,
+`@param`, `@type`), and [tsconfig.json](tsconfig.json) runs `tsc` with
+`checkJs`/`noEmit` — there is **no emit and no compile step**. The browser loads
+`js/game.js` unchanged. The vendored Planck.js engine is untyped, so a thin
+hand-written subset of its API lives in
+[js/planck.esm.d.ts](js/planck.esm.d.ts); extend it if you start calling a
+Planck method the game doesn't use yet. `strictNullChecks` is intentionally off
+(see the comment in tsconfig.json) because the game reaches for
+`getElementById` nodes it knows exist without null guards. When you add a field
+that's assigned after the object literal (e.g. a new `game.*` property set in
+`init()`), declare it on the literal with a `/** @type {...} */` so the checker
+knows its shape.
 
 The tests load [js/game.js](js/game.js) verbatim inside a faked Planck.js + DOM
 harness ([test/helpers/loadGame.js](test/helpers/loadGame.js)) and cover
@@ -57,8 +72,10 @@ walkthrough is still the way to verify rendering and input.
 ```
 index.html                 entry point — loads game.js as an ES module
 css/styles.css             all styling (~100 lines)
-js/game.js                 ALL game code lives here (~1,300 lines), ES module
+js/game.js                 ALL game code lives here (~1,300 lines), ES module, JSDoc-typed
 js/planck.esm.js           Planck.js physics engine, ESM build (vendored, do not edit)
+js/planck.esm.d.ts         hand-written types for the subset of Planck.js the game uses
+tsconfig.json              type-check config (checkJs/noEmit; no build output)
 images/entities/           sprite per entity name (apple.png, burger.png, ...)
 images/backgrounds/        level backgrounds and foregrounds
 images/icons/              UI buttons (play, settings, sound, prev, next, ...)

--- a/js/game.js
+++ b/js/game.js
@@ -1,7 +1,65 @@
+// @ts-check
 import { World, Vec2, Box, Circle } from "./planck.esm.js";
+
+/** @typedef {import("./planck.esm.js").Body} Body */
+/** @typedef {import("./planck.esm.js").Contact} Contact */
+/** @typedef {import("./planck.esm.js").ContactImpulse} ContactImpulse */
+/** @typedef {import("./planck.esm.js").Shape} Shape */
+
+/**
+ * A physics-backed game object: a fruit hero, a junk-food villain, a wood/glass
+ * block, or static ground. Level data supplies the first few fields by hand;
+ * entities.create() fills in the rest from the matching entity definition.
+ * @typedef {Object} Entity
+ * @property {"ground" | "block" | "hero" | "villain"} type
+ * @property {string} name
+ * @property {number} x
+ * @property {number} y
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {number} [radius]
+ * @property {number} [angle]
+ * @property {boolean} [isStatic]
+ * @property {number} [calories] score awarded when a villain is destroyed
+ * @property {number} [health] remaining health; drops via collision damage
+ * @property {number} [fullHealth]
+ * @property {"circle" | "rectangle"} [shape]
+ * @property {HTMLImageElement} [sprite]
+ * @property {HTMLAudioElement} [breakSound]
+ * @property {HTMLAudioElement} [bounceSound]
+ */
+
+/**
+ * The physics and shape parameters shared by every entity of a given name.
+ * @typedef {Object} EntityDefinition
+ * @property {"circle" | "rectangle"} [shape]
+ * @property {number} [fullHealth]
+ * @property {number} [radius]
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {number} density
+ * @property {number} friction
+ * @property {number} restitution
+ */
+
+/**
+ * @typedef {Object} Level
+ * @property {string} foreground
+ * @property {string} background
+ * @property {Entity[]} entities
+ */
+
+/**
+ * The level currently loaded, plus its lazily-loaded background/foreground art.
+ * @typedef {Object} CurrentLevel
+ * @property {number} number
+ * @property {HTMLImageElement} [backgroundImage]
+ * @property {HTMLImageElement} [foregroundImage]
+ */
 
 // Debug flag used to control logging
 const DEBUG = false;
+/** @param {...unknown} args */
 const debugLog = (...args) => {
   if (DEBUG) console.log(...args);
 };
@@ -60,6 +118,39 @@ const game = {
   // Fire Timer to prevent weird friction stuff from making game unplayable
   fireTimer: 0,
 
+  // Properties below are populated during init()/load()/play and declared here
+  // so the type checker knows their shapes. They are not read before assignment.
+  /** @type {HTMLCanvasElement} */
+  canvas: null,
+  /** @type {CanvasRenderingContext2D} */
+  context: null,
+  /** @type {CurrentLevel} */
+  currentLevel: null,
+  /** @type {Body[]} */
+  heroes: [],
+  /** @type {Body[]} */
+  villains: [],
+  /** @type {Body | undefined} */
+  currentHero: undefined,
+  /** @type {Body | undefined} */
+  hero: undefined,
+  ended: false,
+  animationFrame: 0,
+  /** @type {number | undefined} */
+  lastUpdateTime: undefined,
+  /** @type {HTMLImageElement} */
+  slingshotImage: null,
+  /** @type {HTMLImageElement} */
+  slingshotFrontImage: null,
+  /** @type {HTMLAudioElement} */
+  backgroundMusic: null,
+  /** @type {HTMLAudioElement} */
+  bounceSound: null,
+  /** @type {HTMLAudioElement} */
+  slingshotReleasedSound: null,
+  /** @type {Record<string, HTMLAudioElement>} */
+  breakSound: null,
+
   init() {
     //Initialize objects
     levels.init();
@@ -75,24 +166,32 @@ const game = {
     };
 
     // Hide the game and show the start screen
-    document.querySelectorAll(".gamelayer").forEach((el) => {
+    /** @type {NodeListOf<HTMLElement>} */ (
+      document.querySelectorAll(".gamelayer")
+    ).forEach((el) => {
       el.style.display = "none";
     });
     document.getElementById("gamestartscreen").style.display = "block";
 
     // Save canvas and context to game object
-    game.canvas = document.getElementById("gamecanvas");
+    game.canvas = /** @type {HTMLCanvasElement} */ (
+      document.getElementById("gamecanvas")
+    );
     game.context = game.canvas.getContext("2d");
   },
   showLevelScreen() {
-    document.querySelectorAll(".gamelayer").forEach((el) => {
+    /** @type {NodeListOf<HTMLElement>} */ (
+      document.querySelectorAll(".gamelayer")
+    ).forEach((el) => {
       el.style.display = "none";
     });
     document.getElementById("levelselectscreen").style.display = "block";
   },
 
   start() {
-    document.querySelectorAll(".gamelayer").forEach((el) => {
+    /** @type {NodeListOf<HTMLElement>} */ (
+      document.querySelectorAll(".gamelayer")
+    ).forEach((el) => {
       el.style.display = "none";
     });
     document.getElementById("gamecanvas").style.display = "block";
@@ -106,7 +205,11 @@ const game = {
     game.animationFrame = window.requestAnimationFrame(game.animate);
   },
 
-  // Pan the screen to center on newCenter
+  /**
+   * Pan the screen to center on newCenter.
+   * @param {number} newCenter
+   * @returns {boolean} true once the camera has settled on the target or a bound
+   */
   panTo(newCenter) {
     if (
       // Check to see if the newCenter is within a quarter of the game screen in either direction and if the offset is within min and max bounds
@@ -138,6 +241,7 @@ const game = {
     game.heroes = [];
     game.villains = [];
     for (let body = box2d.world.getBodyList(); body; body = body.getNext()) {
+      /** @type {Entity | null} */
       const entity = body.getUserData();
       if (entity) {
         if (entity.type === "hero") {
@@ -285,6 +389,7 @@ const game = {
     }
   },
 
+  /** @param {number} timestamp */
   animate(timestamp) {
     // Animate the background
     game.handlePanning();
@@ -354,6 +459,7 @@ const game = {
     let body = box2d.world.getBodyList();
     while (body) {
       const nextBody = body.getNext();
+      /** @type {Entity | null} */
       const entity = body.getUserData();
       if (entity) {
         const entityX = body.getPosition().x * box2d.scale;
@@ -388,7 +494,7 @@ const game = {
       const previous = parseInt(localStorage.getItem(key) || "0", 10);
       const isNewRecord = game.score > previous;
       if (isNewRecord) {
-        localStorage.setItem(key, game.score);
+        localStorage.setItem(key, String(game.score));
       }
       const recordNote = isNewRecord ? " New best!" : ` Best: ${previous}`;
       if (game.currentLevel.number < levels.data.length - 1) {
@@ -466,18 +572,24 @@ const game = {
   },
 
   startBackgroundMusic() {
-    const toggleImage = document.getElementById("togglemusic");
+    const toggleImage = /** @type {HTMLImageElement} */ (
+      document.getElementById("togglemusic")
+    );
     game.backgroundMusic.play();
     toggleImage.src = "images/icons/sound.png";
   },
   stopBackgroundMusic() {
-    const toggleImage = document.getElementById("togglemusic");
+    const toggleImage = /** @type {HTMLImageElement} */ (
+      document.getElementById("togglemusic")
+    );
     toggleImage.src = "images/icons/nosound.png";
     game.backgroundMusic.pause();
     game.backgroundMusic.currentTime = 0; // make sure to start at beginning of song
   },
   toggleBackgroundMusic() {
-    const toggleImage = document.getElementById("togglemusic");
+    const toggleImage = /** @type {HTMLImageElement} */ (
+      document.getElementById("togglemusic")
+    );
     if (game.backgroundMusic.paused) {
       game.backgroundMusic.play();
       toggleImage.src = "images/icons/sound.png";
@@ -489,6 +601,7 @@ const game = {
 };
 
 const levels = {
+  /** @type {Level[]} */
   data: [
     // Level One
     {
@@ -848,13 +961,16 @@ const levels = {
     levelScreen.innerHTML = html;
     levelScreen.querySelectorAll("input").forEach((input) => {
       input.addEventListener("click", function () {
-        levels.load(this.value - 1);
+        levels.load(Number(input.value) - 1);
         levelScreen.style.display = "none";
       });
     });
   },
 
-  // Load data and images for a selected level
+  /**
+   * Load data and images for a selected level.
+   * @param {number} number
+   */
   load(number) {
     debugLog("load called for ", number);
     box2d.init();
@@ -897,7 +1013,13 @@ const loader = {
   loadedCount: 0,
   totalCount: 0,
   soundFileExtn: ".mp3",
+  /** @type {(() => void) | undefined} called once every queued asset has loaded */
+  onload: undefined,
 
+  /**
+   * @param {string} url
+   * @returns {HTMLImageElement}
+   */
   loadImage(url) {
     this.totalCount++;
     this.loaded = false;
@@ -908,6 +1030,10 @@ const loader = {
     return image;
   },
 
+  /**
+   * @param {string} url
+   * @returns {HTMLAudioElement}
+   */
   loadSound(url) {
     this.totalCount++;
     this.loaded = false;
@@ -942,6 +1068,9 @@ const mouse = {
   x: 0,
   y: 0,
   down: false,
+  dragging: false,
+  downX: 0,
+  downY: 0,
   init() {
     // Register mouse events with our mouse event handlers
     const canvas = document.getElementById("gamecanvas");
@@ -955,6 +1084,7 @@ const mouse = {
     canvas.addEventListener("touchend", mouse.mouseuphandler);
   },
   // Handles general mouse movement on the canvas
+  /** @param {MouseEvent} ev */
   mousemovehandler(ev) {
     // Translate window coordinates to canvas coordinates
     const rect = document.getElementById("gamecanvas").getBoundingClientRect();
@@ -965,6 +1095,7 @@ const mouse = {
     }
   },
   // Handles mouse clicks and drags
+  /** @param {MouseEvent} ev */
   mousedownhandler(ev) {
     mouse.down = true;
     mouse.downX = mouse.x;
@@ -972,10 +1103,12 @@ const mouse = {
     ev.preventDefault();
   },
   // Makes sure that clicks and drags are cut off when the mouse cursor leaves the canvas
+  /** @param {Event} ev */
   mouseuphandler(ev) {
     mouse.down = false;
     mouse.dragging = false;
   },
+  /** @param {TouchEvent} ev */
   touchmovehandler(ev) {
     ev.preventDefault();
     const touch = ev.touches[0];
@@ -986,6 +1119,7 @@ const mouse = {
       mouse.dragging = true;
     }
   },
+  /** @param {TouchEvent} ev */
   touchstarthandler(ev) {
     ev.preventDefault();
     mouse.down = true;
@@ -997,6 +1131,7 @@ const mouse = {
 };
 
 const entities = {
+  /** @type {Record<string, EntityDefinition>} */
   definitions: {
     glass: {
       fullHealth: 100,
@@ -1105,6 +1240,7 @@ const entities = {
     },
   },
   // Turn an entity definition into a Planck.js body and add to game world
+  /** @param {Entity} entity */
   create(entity) {
     const definition = entities.definitions[entity.name];
     debugLog("Definition is ", definition);
@@ -1154,6 +1290,11 @@ const entities = {
   },
   // Draw the entity on the canvas
   // The images are stretched to cover the 1px skin that Planck.js adds to all entities
+  /**
+   * @param {Entity} entity
+   * @param {Vec2} position
+   * @param {number} angle
+   */
   draw(entity, position, angle) {
     game.context.save();
     game.context.translate(
@@ -1216,6 +1357,7 @@ class Box2d {
     this.scale = 30;
     this.velocityIterations = 8;
     this.positionIterations = 3;
+    /** @type {World} */
     this.world = null;
   }
 
@@ -1226,8 +1368,14 @@ class Box2d {
   }
 
   // post-solve handler. Kept as a method so it can be unit-tested directly.
+  /**
+   * @param {Contact} contact
+   * @param {ContactImpulse} impulse
+   */
   handlePostSolve(contact, impulse) {
+    /** @type {Entity | null} */
     const entity1 = contact.getFixtureA().getBody().getUserData();
+    /** @type {Entity | null} */
     const entity2 = contact.getFixtureB().getBody().getUserData();
 
     const impulseAlongNormal = Math.abs(impulse.normalImpulses[0]);
@@ -1244,6 +1392,12 @@ class Box2d {
     }
   }
 
+  /**
+   * @param {Entity} entity
+   * @param {Shape} shape
+   * @param {EntityDefinition} definition
+   * @returns {Body}
+   */
   createBody(entity, shape, definition) {
     const body = this.world.createBody({
       type: entity.isStatic ? "static" : "dynamic",
@@ -1260,6 +1414,11 @@ class Box2d {
     return body;
   }
 
+  /**
+   * @param {Entity} entity
+   * @param {EntityDefinition} definition
+   * @returns {Body}
+   */
   createRectangle(entity, definition) {
     const shape = new Box(
       entity.width / 2 / this.scale,
@@ -1268,11 +1427,17 @@ class Box2d {
     return this.createBody(entity, shape, definition);
   }
 
+  /**
+   * @param {Entity} entity
+   * @param {EntityDefinition} definition
+   * @returns {Body}
+   */
   createCircle(entity, definition) {
     const shape = new Circle(entity.radius / this.scale);
     return this.createBody(entity, shape, definition);
   }
 
+  /** @param {number} timeStep */
   step(timeStep) {
     timeStep = timeStep <= 2 / 60 ? timeStep : 2 / 60;
     this.world.step(timeStep, this.velocityIterations, this.positionIterations);

--- a/js/planck.esm.d.ts
+++ b/js/planck.esm.d.ts
@@ -1,0 +1,86 @@
+// Ambient type declarations for the vendored Planck.js ESM build
+// (js/planck.esm.js). This is a deliberately thin subset: only the surface that
+// js/game.js actually imports and calls is typed, not Planck's full API. It lets
+// `tsc` type-check the game without parsing the 230 KB minified physics engine.
+
+/** A 2D vector. Planck exposes `Vec2` as a factory (called without `new`). */
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+export function Vec2(x: number, y: number): Vec2;
+
+/** Base type for the collision shapes the game builds. */
+export interface Shape {}
+
+/** Axis-aligned box shape, sized by half-width and half-height (in meters). */
+export class Box implements Shape {
+  constructor(halfWidth: number, halfHeight: number);
+}
+
+/** Circle shape, sized by radius (in meters). */
+export class Circle implements Shape {
+  constructor(radius: number);
+}
+
+export interface FixtureDef {
+  shape: Shape;
+  density?: number;
+  friction?: number;
+  restitution?: number;
+}
+
+export interface Fixture {
+  getBody(): Body;
+}
+
+export interface BodyDef {
+  type?: "static" | "dynamic" | "kinematic";
+  position?: Vec2;
+  angle?: number;
+  userData?: unknown;
+}
+
+export interface Body {
+  setUserData(data: unknown): void;
+  /** Returns whatever was stored via setUserData; the game stores its Entity. */
+  getUserData(): any;
+  createFixture(def: FixtureDef): Fixture;
+  getPosition(): Vec2;
+  getAngle(): number;
+  getNext(): Body | null;
+  setPosition(position: Vec2): void;
+  setLinearVelocity(velocity: Vec2): void;
+  setAngularVelocity(omega: number): void;
+  setAwake(flag: boolean): void;
+  isAwake(): boolean;
+  getWorldCenter(): Vec2;
+  applyLinearImpulse(impulse: Vec2, point: Vec2, wake: boolean): void;
+}
+
+export interface Contact {
+  getFixtureA(): Fixture;
+  getFixtureB(): Fixture;
+}
+
+export interface ContactImpulse {
+  normalImpulses: number[];
+  tangentImpulses: number[];
+}
+
+export class World {
+  constructor(gravity: Vec2);
+  on(
+    name: "post-solve",
+    listener: (contact: Contact, impulse: ContactImpulse) => void,
+  ): void;
+  on(name: string, listener: (...args: any[]) => void): void;
+  createBody(def: BodyDef): Body;
+  getBodyList(): Body | null;
+  destroyBody(body: Body): void;
+  step(
+    timeStep: number,
+    velocityIterations?: number,
+    positionIterations?: number,
+  ): void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "eslint": "^9.13.0",
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.8"
       }
     },
@@ -2594,6 +2595,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint .",
+    "typecheck": "tsc",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -14,6 +15,7 @@
     "eslint": "^9.13.0",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  // Type-checks the game source in place via JSDoc. There is no emit and no
+  // build step: the browser still loads js/game.js verbatim. `npm run typecheck`
+  // runs `tsc`, which reads this config and only reports errors.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+
+    "strict": true,
+    // The game reaches for DOM nodes it knows exist (they are declared in
+    // index.html and the test fixture) without null guards, e.g.
+    // document.getElementById("score").innerHTML. Enforcing strict null checks
+    // would demand guards or casts on every such access and change the shipped
+    // file. The rest of strict mode (noImplicitAny, strictFunctionTypes, ...)
+    // stays on and still catches real mistakes.
+    "strictNullChecks": false,
+
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  // Only our source is checked. The vendored, minified Planck build is typed by
+  // its sibling planck.esm.d.ts instead of being parsed.
+  "include": ["js/game.js"],
+  "exclude": ["node_modules", "js/planck.esm.js"]
+}


### PR DESCRIPTION
## What

Migrate the codebase to TypeScript using **JSDoc + `// @ts-check`**, so the source is statically type-checked without introducing a build step. The browser still loads [`js/game.js`](../blob/claude/mystifying-spence-697be7/js/game.js) verbatim — `tsc` runs with `checkJs`/`noEmit`, so there is **no emit and no compile step**.

## Why

Froot Wars ships as a static site with no bundler. A conventional `.ts` → `dist/` migration would break the "runs straight from the static files" property the project is built around. The JSDoc approach keeps the shipped file identical while still giving full static type-checking and editor IntelliSense.

## Changes

- **`js/game.js`** — added `// @ts-check`, JSDoc typedefs (`Entity`, `EntityDefinition`, `Level`, `CurrentLevel`), and `@param`/`@type`/`@returns` annotations throughout. The only non-comment edits are behavior-identical: declaring the lazily-assigned `game.*` / `mouse.*` / `loader.*` properties on their object literals, plus `String(game.score)` and `Number(input.value)` where TS rejects string arithmetic.
- **`js/planck.esm.d.ts`** (new) — hand-written ambient types for the subset of the vendored, untyped Planck.js engine the game uses. `tsc` resolves the `./planck.esm.js` import to this instead of parsing the 230 KB minified bundle.
- **`tsconfig.json`** (new) — `allowJs`/`checkJs`/`noEmit`; `strict` on, with `strictNullChecks` intentionally off (documented inline) because the game accesses `getElementById` nodes it knows exist without null guards.
- **`package.json`** — add `typescript` devDependency and a `typecheck` script (`tsc`).
- **`.github/workflows/ci.yml`** — run `npm run typecheck` between lint and test.
- **`CLAUDE.md`** — document the type-checking setup and conventions.

## Verification

- `npm run typecheck` → 0 errors
- `npm run lint` → clean
- `npm test` → 48/48 passing (the `new Function` harness is unaffected by the added comments/initializers)
- In-browser smoke test (the native-ESM `import` + `DOMContentLoaded` path the unit tests don't cover): served over HTTP, clicked start → level select → level 1 loaded and rendered with **zero console messages**.

## Notes for reviewers

- No runtime behavior change is intended; the diff is JSDoc comments plus harmless property declarations and two coercions.
- `strictNullChecks` is off by design — flipping it on would require null guards/casts across the DOM-heavy code. The typedefs are in place if we ever want to tighten it.
- If a future change calls a Planck method the game doesn't use yet, extend `js/planck.esm.d.ts` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)