### PR TITLE
fix(deps): bump undici 7.27.2 → 7.28.0 (security)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^7.28.0
+
 importers:
 
   .:
@@ -775,8 +778,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
@@ -1353,7 +1356,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -1568,7 +1571,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  undici: "^7.28.0"


### PR DESCRIPTION
## Summary

- Adds [`pnpm-workspace.yaml`](pnpm-workspace.yaml) with an `overrides` block pinning `undici` to `^7.28.0`. This is the pnpm v11 replacement for the old `package.json["pnpm"]["overrides"]` field (pnpm now ignores that field and emits a warning).
- Updates `pnpm-lock.yaml` to resolve `undici` from 7.27.2 → 7.28.0.

`undici` is a transitive dev dependency (pulled in by `jsdom`). The upgrade addresses two Dependabot security alerts:

| Alert | Severity |
|---|---|
| #11 — TLS certificate validation bypass via dropped `requestTls` in SOCKS5 `ProxyAgent` | **High** |
| #10 — Cross-user information disclosure via shared cache whitespace bypass | Moderate |

## Test plan

- [x] `npm test` — all 48 tests pass with the updated `undici`
- [x] `pnpm install` runs clean with no warnings about ignored config keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)