### PR TITLE
ci: add explicit permissions to restrict GITHUB_TOKEN scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the CI workflow job to address [CodeQL alert #3](https://github.com/bushidocodes/froot-wars/security/code-scanning/3) (`actions/missing-workflow-permissions`)
- The `check` job only reads the repository to run lint, type-check, and tests — no write access is needed
- Follows the principle of least privilege and documents the actual token requirements explicitly

## Test plan

- [ ] CI passes on this PR
- [ ] CodeQL alert #3 closes after merge (GitHub auto-resolves `missing-workflow-permissions` alerts when the fix lands on the default branch)