### PR TITLE
Add Dependabot cooldown (default-days: 3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds a `cooldown` block with `default-days: 3` to each `updates` entry in `.github/dependabot.yml`, so version bumps wait 3 days after release before Dependabot opens a PR. This avoids getting hit by a bad or yanked release the same day it ships.

Applied to both the `npm` and `github-actions` ecosystems.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)