### PR TITLE
chore: reduce Dependabot noise (monthly + groups + limits)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,26 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'monthly'
+    open-pull-requests-limit: 5
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
     cooldown:
-      default-days: 3
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'monthly'
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - '*'
     cooldown:
-      default-days: 3
+      default-days: 7


### PR DESCRIPTION
## Summary

Reduce Dependabot PR spam while keeping version updates on:

- **Schedule:** `weekly` → `monthly`
- **Groups:** bundle all `github-actions` updates; split npm into production/development
- **Open PR limit:** `1` for Actions (if unset), `5` for other ecosystems (if unset)
- **Cooldown:** `default-days: 7` (set or raised from lower values)

## Notes

- Existing `ignore` rules preserved (comments may be dropped by YAML re-serialization)
- Security updates / Dependabot alerts are unchanged

## Test plan

- [ ] CI green on this PR
- [ ] `.github/dependabot.yml` validates (Dependabot config syntax)
